### PR TITLE
`gator` for ci too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         run: |
           rm -rf test
           rm .github/workflows/ci.yml
-          ./gator test -f .
+          ./gator test -f . --output=json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 jobs:
-  ci:
+  gator:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -21,4 +21,15 @@ jobs:
         run: |
           rm -rf test
           rm .github/workflows/ci.yml
-          ./gator test -f . --output=json
+          ./gator test -f .
+  kpt:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: install kpt
+        run: |
+          curl -L https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.14/kpt_linux_amd64 > kpt
+          chmod +x kpt
+      - name: gatekeeper
+        run: |
+          ./kpt fn eval . --image gcr.io/kpt-fn/gatekeeper:v0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,7 @@ jobs:
       - name: gator verify
         run: ./gator verify test/suite.yaml
       - name: gator test
-        run: ./gator test -f .
+        run: |
+          rm -rf test
+          rm .github/workflows/ci.yml
+          ./gator test -f .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 jobs:
-  gator:
+  ci:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -14,17 +14,8 @@ jobs:
           curl -OL https://github.com/open-policy-agent/gatekeeper/releases/download/v${GATOR_VERSION}/gator-v${GATOR_VERSION}-linux-amd64.tar.gz
           tar xvf gator-v${GATOR_VERSION}-linux-amd64.tar.gz && rm gator-v${GATOR_VERSION}-linux-amd64.tar.gz
         env:
-          GATOR_VERSION: 3.7.1
-      - name: gator test
+          GATOR_VERSION: 3.8.0
+      - name: gator test -v
         run: ./gator test -v test/suite.yaml
-  kpt:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: install kpt
-        run: |
-          curl -L https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.14/kpt_linux_amd64 > kpt
-          chmod +x kpt
-      - name: gatekeeper
-        run: |
-          ./kpt fn eval . --image gcr.io/kpt-fn/gatekeeper:v0.2
+      - name: gator test -f
+        run: ./gator test -f .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           tar xvf gator-v${GATOR_VERSION}-linux-amd64.tar.gz && rm gator-v${GATOR_VERSION}-linux-amd64.tar.gz
         env:
           GATOR_VERSION: 3.8.0
-      - name: gator test -v
-        run: ./gator test -v test/suite.yaml
-      - name: gator test -f
+      - name: gator verify
+        run: ./gator verify test/suite.yaml
+      - name: gator test
         run: ./gator test -f .


### PR DESCRIPTION
Update `gator` to [v3.8.0](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.8.0) and add an example where `gator` is able to test actual Kubernetes manifests against `Constraints` and `ConstraintTemplates`. Note: keeping the `kpt` way as well for more options and examples.